### PR TITLE
Import ethers in borrow.js

### DIFF
--- a/src/borrow.js
+++ b/src/borrow.js
@@ -1,4 +1,5 @@
 import { WAD } from './utils';
+import { constants, BigNumber } from 'ethers';
 
 /**
  * Deducts slippage from an exchange rate
@@ -45,9 +46,9 @@ export function debtToNormalDebt(debt, rate) {
  * @return collateralization ratio [wad]
  */
 export function computeCollateralizationRatio(collateral, fairPrice, normalDebt, rate) {
-  if (collateral.isZero()) return ethers.BigNumber.from(0);
+  if (collateral.isZero()) return BigNumber.from(0);
   const debt = normalDebtToDebt(normalDebt, rate);
-  if (debt.isZero()) return ethers.BigNumber.from(ethers.constants.MaxUint256);
+  if (debt.isZero()) return BigNumber.from(constants.MaxUint256);
   return collateral.mul(fairPrice).div(debt);
 }
 

--- a/src/borrow.js
+++ b/src/borrow.js
@@ -1,5 +1,5 @@
 import { WAD } from './utils';
-import { constants, BigNumber } from 'ethers';
+import { ethers } from 'ethers';
 
 /**
  * Deducts slippage from an exchange rate
@@ -46,9 +46,9 @@ export function debtToNormalDebt(debt, rate) {
  * @return collateralization ratio [wad]
  */
 export function computeCollateralizationRatio(collateral, fairPrice, normalDebt, rate) {
-  if (collateral.isZero()) return BigNumber.from(0);
+  if (collateral.isZero()) return ethers.BigNumber.from(0);
   const debt = normalDebtToDebt(normalDebt, rate);
-  if (debt.isZero()) return BigNumber.from(constants.MaxUint256);
+  if (debt.isZero()) return ethers.BigNumber.from(ethers.constants.MaxUint256);
   return collateral.mul(fairPrice).div(debt);
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -146,7 +146,7 @@ describe('Borrow', () => {
     expect(normalDebt.eq(positionData.normalDebt)).toBe(true);
   });
 
-  test.only('applySwapSlippage', async () => {
+  test('applySwapSlippage', async () => {
     expect(applySwapSlippage(WAD, decToWad(0.001)).eq(decToWad(0.999))).toBe(true);
   });
 });


### PR DESCRIPTION
Using computeCollateralizationRatio in the lever app was causing an error

> Unhandled Runtime Error
> ReferenceError: ethers is not defined

