### PR TITLE
Fetch User Data via Ethers Provider

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -437,16 +437,6 @@ export class FIAT {
 
   async fetchUserDataProvider(owner) { // owner is assumed as the proxy right now
     const contracts = this.getContracts();
-
-    /*
-    // This throws heap out of memory errors or rate limit errors from provider
-    const proxyFilter = await contracts.proxyFactory.filters.DeployProxy(null, null, owner);
-    const proxyEvents = await contracts.proxyFactory.queryFilter(
-      proxyFilter,
-      14554754
-    );
-    */
-
     const collateralTypes = Object.keys(this.metadata).reduce((collateralTypes_, vault) => (
       [ ...collateralTypes_, ...this.metadata[vault].tokenIds.map((tokenId) => ({ vault, tokenId })) ]
     ), []);
@@ -456,22 +446,34 @@ export class FIAT {
     });
     const tokenAddressPromise = this.multicall(tokenAddressMapping);
 
-    const proxyPromise = this.multicall([
+    const proxyQueryPromise = this.multicall([
       { contract: contracts.proxyFactory, method: 'isProxy', args: [owner]},
       { contract: contracts.proxyRegistry, method: 'getCurrentProxy', args: [owner]}
     ]);
 
-    const [ tokenAddressResults, proxyResults ] = await Promise.all([tokenAddressPromise, proxyPromise]);
+    const [ tokenAddressResults, proxyResults ] = await Promise.all([tokenAddressPromise, proxyQueryPromise]);
     const [isProxy, proxyAddress] = proxyResults;
 
     const addresses = isProxy || !proxyAddress ? [owner] : [owner, proxyResults[1]]
     const userData = [];
 
+    // Check balances for owner address + proxies
     for (const address of addresses) {
       const balancesMapping = collateralTypes.map(item => {
         return { contract: contracts.codex, method: 'balances', args: [item.vault, item.tokenId, address] }
       });
-      const balanceResults = await this.multicall(balancesMapping);
+      const positionCallMapping = collateralTypes.map(item => {
+        return { contract: contracts.codex, method: 'positions', args: [item.vault, item.tokenId, address] }
+      });
+      const balanceResultsPromise = await this.multicall(balancesMapping);
+      const positionResultsPromise = await this.multicall(positionCallMapping);
+      const creditDebtPromise = await this.multicall([
+        { contract: contracts.codex, method: 'credit', args: [address] },
+        { contract: contracts.codex, method: 'unbackedDebt', args: [address] },
+      ]);
+
+      const [ balanceResults, positionResults, [credit, unbackedDebt]] = await Promise.all([balanceResultsPromise, positionResultsPromise, creditDebtPromise]);
+
       const balances = balanceResults.map((item, index) => {
         return {
           balance: balanceResults[index],
@@ -481,11 +483,6 @@ export class FIAT {
           }
         }
       });
-  
-      const positionCallMapping = collateralTypes.map(item => {
-        return { contract: contracts.codex, method: 'positions', args: [item.vault, item.tokenId, address] }
-      });
-      const positionResults = await this.multicall(positionCallMapping);
       const positions = positionResults.map((item, index) => {
         return {
           collateral: item.collateral,
@@ -496,18 +493,12 @@ export class FIAT {
           vault: collateralTypes[index].vault,
         }
       });
-  
-      const [credit, unbackedDebt] = await this.multicall([
-        { contract: contracts.codex, method: 'credit', args: [address] },
-        { contract: contracts.codex, method: 'unbackedDebt', args: [address] },
-      ])
-  
       userData.push({
         balances,
         positions,
         credit,
         unbackedDebt,
-        isProxy: address === owner && isProxy,
+        isProxy: (address === owner && isProxy) || (address === proxyAddress),
         delegates: [], // todo
         delegated: [], // todo
       })

--- a/src/index.js
+++ b/src/index.js
@@ -435,7 +435,7 @@ export class FIAT {
     }));
   }
 
-  async fetchUserDataProvider(owner) { // owner is assumed as the proxy right now
+  async fetchUserDataProvider(owner) {
     const contracts = this.getContracts();
     const collateralTypes = Object.keys(this.metadata).reduce((collateralTypes_, vault) => (
       [ ...collateralTypes_, ...this.metadata[vault].tokenIds.map((tokenId) => ({ vault, tokenId })) ]
@@ -479,7 +479,7 @@ export class FIAT {
         return resultArray.push({
           balance: balanceResults[index],
           collateralType: {
-            token: tokenAddressResults[index],
+            token: tokenAddressResults[index].toLowerCase(),
             tokenId: collateralTypes[index].tokenId
           }
         })
@@ -489,16 +489,16 @@ export class FIAT {
         resultArray.push({
           collateral: item.collateral,
           normalDebt: item.normalDebt,
-          owner: address,
-          token: tokenAddressResults[index],
+          owner: address.toLowerCase(),
+          token: tokenAddressResults[index].toLowerCase(),
           tokenId: ethers.BigNumber.from(collateralTypes[index].tokenId),
-          vault: collateralTypes[index].vault,
+          vault: collateralTypes[index].vault.toLowerCase(),
         })
         return resultArray;
       }, []);
       if (balances.length === 0 && positions.length === 0) continue;
       userData.push({
-        user: address,
+        user: address.toLowerCase(),
         balances,
         positions,
         credit,

--- a/src/index.js
+++ b/src/index.js
@@ -486,23 +486,26 @@ export class FIAT {
       }, []);
       const positions = positionResults.reduce((resultArray, item, index) => {
         if (item.collateral.eq(0) && item.normalDebt.eq(0)) return resultArray;
-        return resultArray.push({
+        resultArray.push({
           collateral: item.collateral,
           normalDebt: item.normalDebt,
           owner: address,
           token: tokenAddressResults[index],
-          tokenId: collateralTypes[index].tokenId,
+          tokenId: ethers.BigNumber.from(collateralTypes[index].tokenId),
           vault: collateralTypes[index].vault,
         })
+        return resultArray;
       }, []);
+      if (balances.length === 0 && positions.length === 0) continue;
       userData.push({
+        user: address,
         balances,
         positions,
         credit,
         unbackedDebt,
         isProxy: (address === owner && isProxy) || (address === proxyAddress),
-        delegates: [], // todo
-        delegated: [], // todo
+        delegates: [],
+        delegated: [],
       });
     }
     return userData;

--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,7 @@ import LeverSPTActions from 'changelog/abis/LeverSPTActions.sol/LeverSPTActions.
 import {
   SUBGRAPH_URL_MAINNET, SUBGRAPH_URL_GOERLI, queryCollateralTypes, queryUser, queryUserProxies
 } from './queries';
-import { addressEq } from './utils';
+import { addressEq, ADDRESS_ZERO } from './utils';
 
 // mute 'duplicate event' abi error
 ethers.utils.Logger.setLogLevel(ethers.utils.Logger.levels.ERROR);
@@ -451,7 +451,7 @@ export class FIAT {
       ])
     ]);
 
-    const addresses = (isProxy || !proxyAddress) ? [owner] : [owner, proxyAddress]
+    const addresses = (isProxy || proxyAddress === ADDRESS_ZERO) ? [owner] : [owner, proxyAddress];
 
     // Check balances for owner address + proxies
     const asyncUserData = async (address) => {
@@ -501,6 +501,6 @@ export class FIAT {
     }
     
     return (await Promise.all(addresses.map((address) => asyncUserData(address))))
-      .filter((item) => item.balances.length > 0 || item.positions.length > 0);
+      .filter((item) => item.isProxy || item.balances.length > 0 || item.positions.length > 0);
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -474,25 +474,27 @@ export class FIAT {
 
       const [ balanceResults, positionResults, [credit, unbackedDebt]] = await Promise.all([balanceResultsPromise, positionResultsPromise, creditDebtPromise]);
 
-      const balances = balanceResults.map((item, index) => {
-        return {
+      const balances = balanceResults.reduce((resultArray, item, index) => {
+        if (balanceResults[index].eq(0)) return resultArray;
+        return resultArray.push({
           balance: balanceResults[index],
           collateralType: {
             token: tokenAddressResults[index],
             tokenId: collateralTypes[index].tokenId
           }
-        }
-      });
-      const positions = positionResults.map((item, index) => {
-        return {
+        })
+      }, []);
+      const positions = positionResults.reduce((resultArray, item, index) => {
+        if (item.collateral.eq(0) && item.normalDebt.eq(0)) return resultArray;
+        return resultArray.push({
           collateral: item.collateral,
           normalDebt: item.normalDebt,
           owner: address,
           token: tokenAddressResults[index],
           tokenId: collateralTypes[index].tokenId,
           vault: collateralTypes[index].vault,
-        }
-      });
+        })
+      }, []);
       userData.push({
         balances,
         positions,
@@ -501,7 +503,7 @@ export class FIAT {
         isProxy: (address === owner && isProxy) || (address === proxyAddress),
         delegates: [], // todo
         delegated: [], // todo
-      })
+      });
     }
     return userData;
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,6 +3,8 @@ import { ethers } from 'ethers';
 export const ZERO = ethers.constants.Zero;
 export const WAD = ethers.utils.parseUnits('1', '18');
 
+export const ADDRESS_ZERO = ethers.constants.AddressZero;
+
 // decimal: BigNumberish -> BigNumber
 export function decToWad(decimal) {
   return ethers.utils.parseUnits(String(decimal), '18');

--- a/test/test.js
+++ b/test/test.js
@@ -631,7 +631,7 @@ describe('FIAT', () => {
 
   test.only('fetchUserDataProvider', async () => {
     const userData = await fiat.fetchUserDataProvider("0xF1A7dA08F6cb83069817d2D8F6e55E4F2D6C0834");
-    console.log({userData})
+    console.log(JSON.stringify(userData, null, 2));
   });
 
   test('queryVault', async () => {

--- a/test/test.js
+++ b/test/test.js
@@ -629,6 +629,11 @@ describe('FIAT', () => {
     expect(userData4[0].isProxy).toBe(true);
   });
 
+  test.only('fetchUserDataProvider', async () => {
+    const userData = await fiat.fetchUserDataProvider("0xF1A7dA08F6cb83069817d2D8F6e55E4F2D6C0834");
+    console.log({userData})
+  });
+
   test('queryVault', async () => {
     const result = await fiat.query(
       queryVault, { id: ADDRESSES_MAINNET.vaultEPT_ePyvDAI_24FEB23.address.toLowerCase() }

--- a/test/test.js
+++ b/test/test.js
@@ -629,8 +629,22 @@ describe('FIAT', () => {
     expect(userData4[0].isProxy).toBe(true);
   });
 
-  test('fetchUserDataProvider', async () => {
-    const userData = await fiat.fetchUserDataProvider(proxyOwner);
+  test.only('fetchUserDataViaProvider', async () => {
+    const userData = await fiat.fetchUserData('0x9763b704f3fd8d70914d2d1293da4b7c1a38702c');
+    const userDataViaProvider = await fiat.fetchUserDataViaProvider('0x9763b704f3fd8d70914d2d1293da4b7c1a38702c');
+    expect(userDataViaProvider[0].isProxy).toBe(userData[0].isProxy);
+    expect(userDataViaProvider[0].positions[0].collateral.eq(userData[0].positions[0].collateral)).toBe(true);
+    const userData2 = await fiat.fetchUserData('0xcD6998D20876155D37aEC0dB4C19d63EEAEf058F');
+    const userDataViaProvider2 = await fiat.fetchUserDataViaProvider('0xcD6998D20876155D37aEC0dB4C19d63EEAEf058F');
+    expect(userDataViaProvider2[0].isProxy).toBe(userData2[0].isProxy);
+    const userData3 = await fiat.fetchUserData(defaultAccount);
+    const userDataViaProvider3 = await fiat.fetchUserDataViaProvider(defaultAccount);
+    expect(userDataViaProvider3.length).toBe(userData3.length);
+    const userData4 = await fiat.fetchUserData('0xF1A7dA08F6cb83069817d2D8F6e55E4F2D6C0834');
+    console.log(userData4);
+    const userDataViaProvider4 = await fiat.fetchUserDataViaProvider('0xF1A7dA08F6cb83069817d2D8F6e55E4F2D6C0834');
+    console.log(userDataViaProvider4);
+    expect(userDataViaProvider4[0].isProxy).toBe(userData4[0].isProxy);
   });
 
   test('queryVault', async () => {

--- a/test/test.js
+++ b/test/test.js
@@ -629,9 +629,8 @@ describe('FIAT', () => {
     expect(userData4[0].isProxy).toBe(true);
   });
 
-  test.only('fetchUserDataProvider', async () => {
-    const userData = await fiat.fetchUserDataProvider("0xF1A7dA08F6cb83069817d2D8F6e55E4F2D6C0834");
-    console.log(JSON.stringify(userData, null, 2));
+  test('fetchUserDataProvider', async () => {
+    const userData = await fiat.fetchUserDataProvider(proxyOwner);
   });
 
   test('queryVault', async () => {

--- a/test/test.js
+++ b/test/test.js
@@ -641,9 +641,7 @@ describe('FIAT', () => {
     const userDataViaProvider3 = await fiat.fetchUserDataViaProvider(defaultAccount);
     expect(userDataViaProvider3.length).toBe(userData3.length);
     const userData4 = await fiat.fetchUserData('0xF1A7dA08F6cb83069817d2D8F6e55E4F2D6C0834');
-    console.log(userData4);
     const userDataViaProvider4 = await fiat.fetchUserDataViaProvider('0xF1A7dA08F6cb83069817d2D8F6e55E4F2D6C0834');
-    console.log(userDataViaProvider4);
     expect(userDataViaProvider4[0].isProxy).toBe(userData4[0].isProxy);
   });
 


### PR DESCRIPTION
Replicates fetchUserData call without requiring subgraph queries.

Note it is assumed that the owner address parameter is the proxy. I am not sure how to handle the owner parameter in the positions object without calling positions in codex for both the user address and possible proxy.

Other todos are regarding delegated and delegates.